### PR TITLE
chore: add direnv support and download helm binary

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+export KUBECONFIG="$PWD/.kubeconfig"
+export KIND_CLUSTER_NAME="capsule-argocd-addon"
+export PATH="$PWD/bin:$PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ public/
 .cache/
 .tmp
 *trivy*
+.kubeconfig


### PR DESCRIPTION
- The `.envrc` file adds https://direnv.net/ support, which basically means that the environment variables are exported when entering the directory.
- I updated the `Makefile` to automatically download the specified helm release.