### PR TITLE
fix(helm): remove duplicate namespace entry in rbac.yaml

### DIFF
--- a/charts/capsule-argo-addon/templates/rbac.yaml
+++ b/charts/capsule-argo-addon/templates/rbac.yaml
@@ -124,7 +124,6 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "helm.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Followup https://github.com/peak-scale/capsule-argo-addon/pull/266

This issue is currently blocking chart installation. Can you please build a new release asap? Thank you