### PR TITLE
fix(controller): try to cause less update conflicts

### DIFF
--- a/api/v1alpha1/argotranslator_func.go
+++ b/api/v1alpha1/argotranslator_func.go
@@ -147,16 +147,16 @@ func (in *ArgoTranslator) CollectStatus() {
 	in.updateReadyStatus()
 }
 
-// Assign Tenants to the ArgoTranslator.
-func (in *ArgoTranslator) SyncFinalizerStatus() {
+// Assign Tenants to the ArgoTranslator. Returns true if finalizer status was changed.
+func (in *ArgoTranslator) SyncFinalizerStatus() bool {
 	size := uint(len(in.Status.Tenants))
 
 	// Keep or remove Finalizer based on status inventory
 	if size > 0 {
-		controllerutil.AddFinalizer(in, meta.ControllerFinalizer)
-	} else {
-		controllerutil.RemoveFinalizer(in, meta.ControllerFinalizer)
+		return controllerutil.AddFinalizer(in, meta.ControllerFinalizer)
 	}
+
+	return controllerutil.RemoveFinalizer(in, meta.ControllerFinalizer)
 }
 
 // Assign Tenants to the ArgoTranslator.

--- a/e2e/settings_translation_test.go
+++ b/e2e/settings_translation_test.go
@@ -302,6 +302,17 @@ var _ = Describe("Translation Test", func() {
 			Expect(condition.Reason).To(Equal(meta.SucceededReason), "Expected tenant condition reason to be Succeeded")
 		})
 
+		By("verify primary translator finalizer", func() {
+			tra := &v1alpha1.ArgoTranslator{}
+			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: translator1.Name}, tra)).To(Succeed())
+
+			expectedFinalizers := []string{
+				meta.ControllerFinalizer,
+			}
+
+			Expect(tra.Finalizers).To(Equal(expectedFinalizers), "Translator should have the expected finalizers")
+		})
+
 		By("create second translation", func() {
 			Expect(k8sClient.Create(context.TODO(), translator2)).ToNot(HaveOccurred())
 		})
@@ -401,6 +412,17 @@ var _ = Describe("Translation Test", func() {
 			Expect(condition.Reason).To(Equal(meta.SucceededReason), "Expected tenant condition reason to be Succeeded")
 		})
 
+		By("verify secondary translator finalizer", func() {
+			tra := &v1alpha1.ArgoTranslator{}
+			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: translator2.Name}, tra)).To(Succeed())
+
+			expectedFinalizers := []string{
+				meta.ControllerFinalizer,
+			}
+
+			Expect(tra.Finalizers).To(Equal(expectedFinalizers), "Translator should have the expected finalizers")
+		})
+
 		By("primary translator should no longer select tenant", func() {
 			translator := &v1alpha1.ArgoTranslator{}
 			Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Name: translator1.Name}, translator)).ToNot(HaveOccurred())
@@ -418,6 +440,13 @@ var _ = Describe("Translation Test", func() {
 
 			condition := tra.GetTenantCondition(solar)
 			Expect(condition).To(BeNil(), "Tenant condition should not be nil")
+		})
+
+		By("verify primary translator finalizer (no longer selecting)", func() {
+			tra := &v1alpha1.ArgoTranslator{}
+			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: translator1.Name}, tra)).To(Succeed())
+
+			Expect(tra.Finalizers).To(BeEmpty(), "Translator should have no finalizers")
 		})
 
 		By("verify translated approject (subtract primary translator)", func() {

--- a/internal/controllers/tenant/controller_appproject.go
+++ b/internal/controllers/tenant/controller_appproject.go
@@ -63,7 +63,16 @@ func (i *Reconciler) reconcileProject(
 
 			// Update Translator
 			errs = retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
-				return i.Client.Status().Update(ctx, translator)
+				currentTranslator := &configv1alpha1.ArgoTranslator{}
+
+				err = i.Client.Get(ctx, client.ObjectKeyFromObject(translator), currentTranslator)
+				if err != nil {
+					return err
+				}
+
+				translator.Status.DeepCopyInto(&currentTranslator.Status)
+
+				return i.Client.Status().Update(ctx, currentTranslator)
 			})
 
 			log.V(7).Info("updated", "translation", translator.Name, "err", err)

--- a/internal/controllers/translator/controller.go
+++ b/internal/controllers/translator/controller.go
@@ -45,31 +45,30 @@ func (i *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	log := i.Log.WithValues("translator", request.Name)
 
 	origin := &configv1alpha1.ArgoTranslator{}
-	if err := i.Client.Get(ctx, request.NamespacedName, origin); err != nil {
-		if k8serrors.IsNotFound(err) {
-			log.Info("Request object not found, could have been deleted after reconcile request")
 
-			// Cleanup Metricss
-			i.Metrics.DeleteTranslatorCondition(request.Name)
-
-			return reconcile.Result{}, nil
-		}
-
-		return reconcile.Result{}, err
-	}
-
-	// Emit Metrics
-	i.Metrics.RecordTranslatorCondition(origin)
-
-	// Synchronize Finalizer status
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
-		if err := i.Client.Update(ctx, origin); err != nil {
-			origin.SyncFinalizerStatus()
+		if err := i.Client.Get(ctx, request.NamespacedName, origin); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Info("Request object not found, could have been deleted after reconcile request")
+
+				// Cleanup Metricss
+				i.Metrics.DeleteTranslatorCondition(request.Name)
+
+				return nil
+			}
 
 			return err
 		}
 
-		return
+		// Emit Metrics
+		i.Metrics.RecordTranslatorCondition(origin)
+
+		// Synchronize Finalizer status
+		if origin.SyncFinalizerStatus() {
+			return i.Client.Update(ctx, origin)
+		}
+
+		return nil
 	}); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
I've run into quite a lot of reconcile errors caused by conflicts in the resource to be updated, filling logs with errors like 

```
the object has been modified; please apply your changes to the latest version and try again
```

This PR tries to fix, or at least reduce the number of caused conflicts by trying to be as close to the live resource as possible.

---

### Copilot generated summary

This pull request refactors how status updates and finalizer synchronization are handled for `ArgoTranslator` resources, improving reliability and correctness during concurrent updates. The main changes focus on ensuring that status updates and finalizer modifications are performed safely and only when necessary, using deep copies and conflict-aware operations.

**Finalizer and Status Synchronization Improvements:**

* Changed the `SyncFinalizerStatus` method in `ArgoTranslator` to return a boolean indicating if the finalizer status was modified, and to only update the finalizer when necessary.
* Updated the `Reconcile` method in `controller.go` to only call `Client.Update` if the finalizer status was actually changed, reducing unnecessary updates.

**Status Update Reliability:**

* In `controller_appproject.go`, refactored the status update logic to fetch the current `ArgoTranslator` object from the API, copy the new status into it, and then perform the status update. This ensures updates are conflict-aware and prevents overwriting concurrent changes.