### PR TITLE
fix(helm): duplicate namespace definition, fix #268

### DIFF
--- a/charts/capsule-argo-addon/templates/rbac.yaml
+++ b/charts/capsule-argo-addon/templates/rbac.yaml
@@ -124,7 +124,6 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "helm.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
the namespace is declared twice, removed duplciate
```
  namespace: {{ $.Release.Namespace }}
  ...
  namespace: {{ .Release.Namespace | quote }}
  ```