### PR TITLE
fix(translator): prune stale tenant status

### DIFF
--- a/api/v1alpha1/argotranslator_func.go
+++ b/api/v1alpha1/argotranslator_func.go
@@ -14,6 +14,7 @@ import (
 	"github.com/peak-scale/capsule-argo-addon/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -156,6 +157,43 @@ func (in *ArgoTranslator) SyncFinalizerStatus() {
 		controllerutil.AddFinalizer(in, meta.ControllerFinalizer)
 	} else {
 		controllerutil.RemoveFinalizer(in, meta.ControllerFinalizer)
+	}
+}
+
+// PruneMissingTenantStatuses removes status entries for tenants that no longer exist.
+func (in *ArgoTranslator) PruneMissingTenantStatuses(tenants []capsulev1beta2.Tenant) {
+	if len(in.Status.Tenants) == 0 {
+		return
+	}
+
+	liveTenants := make(map[string]k8stypes.UID, len(tenants))
+	for _, tenant := range tenants {
+		liveTenants[tenant.Name] = tenant.UID
+	}
+
+	filteredTenants := make([]TenantStatus, 0, len(in.Status.Tenants))
+	changed := false
+
+	for _, tenant := range in.Status.Tenants {
+		uid, ok := liveTenants[tenant.Name]
+		if !ok {
+			changed = true
+
+			continue
+		}
+
+		if tenant.UID != "" && uid != "" && tenant.UID != uid {
+			changed = true
+
+			continue
+		}
+
+		filteredTenants = append(filteredTenants, tenant)
+	}
+
+	if changed {
+		in.Status.Tenants = filteredTenants
+		in.CollectStatus()
 	}
 }
 

--- a/api/v1alpha1/argotranslator_func_test.go
+++ b/api/v1alpha1/argotranslator_func_test.go
@@ -1,10 +1,13 @@
 package v1alpha1
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/peak-scale/capsule-argo-addon/internal/meta"
 	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 func TestReconcileTranslator_WithEmptySelector_ShouldMatchAllTenants(t *testing.T) {
@@ -114,5 +117,65 @@ func TestReconcileTranslator_WithEmptySelector_ShouldMatchOneTenant(t *testing.T
 
 	if len(matchedTenants) != 1 {
 		t.Errorf("expected 1 tenants to match, got %d", len(matchedTenants))
+	}
+}
+
+func TestPruneMissingTenantStatuses_RemovesStaleTenants(t *testing.T) {
+	translator := &ArgoTranslator{
+		Status: ArgoTranslatorStatus{
+			Tenants: []TenantStatus{
+				{
+					Name: "tenant-a",
+					UID:  k8stypes.UID("uid-a"),
+					Condition: metav1.Condition{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				{
+					Name: "tenant-b",
+					UID:  k8stypes.UID("uid-b"),
+					Condition: metav1.Condition{
+						Type:   "Ready",
+						Status: metav1.ConditionFalse,
+					},
+				},
+				{
+					Name: "tenant-c",
+					UID:  k8stypes.UID("old-uid-c"),
+					Condition: metav1.Condition{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				{
+					Name: "tenant-d",
+					Condition: metav1.Condition{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+	translator.CollectStatus()
+
+	translator.PruneMissingTenantStatuses([]capsulev1beta2.Tenant{
+		{ObjectMeta: metav1.ObjectMeta{Name: "tenant-a", UID: k8stypes.UID("uid-a")}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "tenant-c", UID: k8stypes.UID("new-uid-c")}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "tenant-d", UID: k8stypes.UID("uid-d")}},
+	})
+
+	want := []string{"tenant-a", "tenant-d"}
+	if got := translator.GetTenantNames(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected tenants %v, got %v", want, got)
+	}
+
+	if translator.Status.Size != 2 {
+		t.Fatalf("expected status size 2, got %d", translator.Status.Size)
+	}
+
+	if translator.Status.Ready != meta.ReadyCondition {
+		t.Fatalf("expected ready status %q, got %q", meta.ReadyCondition, translator.Status.Ready)
 	}
 }

--- a/internal/controllers/translator/controller.go
+++ b/internal/controllers/translator/controller.go
@@ -5,6 +5,7 @@ package translator
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	configv1alpha1 "github.com/peak-scale/capsule-argo-addon/api/v1alpha1"
@@ -18,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 )
 
 var _ reconcile.Reconciler = &Reconciler{}
@@ -58,21 +61,83 @@ func (i *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
+	pruned, err := i.pruneMissingTenantStatuses(ctx, request.NamespacedName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if pruned {
+		if err := i.Client.Get(ctx, request.NamespacedName, origin); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Emit Metrics
 	i.Metrics.RecordTranslatorCondition(origin)
 
 	// Synchronize Finalizer status
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
-		if err := i.Client.Update(ctx, origin); err != nil {
-			origin.SyncFinalizerStatus()
-
-			return err
-		}
-
-		return
-	}); err != nil {
+	if err := i.syncFinalizerStatus(ctx, request.NamespacedName); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (i *Reconciler) pruneMissingTenantStatuses(ctx context.Context, key client.ObjectKey) (bool, error) {
+	tenants := &capsulev1beta2.TenantList{}
+	if err := i.Client.List(ctx, tenants); err != nil {
+		return false, err
+	}
+
+	pruned := false
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &configv1alpha1.ArgoTranslator{}
+		if err := i.Client.Get(ctx, key, current); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		previous := current.Status.DeepCopy()
+
+		current.PruneMissingTenantStatuses(tenants.Items)
+
+		if reflect.DeepEqual(previous, current.Status.DeepCopy()) {
+			return nil
+		}
+
+		pruned = true
+
+		return i.Client.Status().Update(ctx, current)
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return pruned, nil
+}
+
+func (i *Reconciler) syncFinalizerStatus(ctx context.Context, key client.ObjectKey) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current := &configv1alpha1.ArgoTranslator{}
+		if err := i.Client.Get(ctx, key, current); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		previous := current.DeepCopy()
+		current.SyncFinalizerStatus()
+
+		if reflect.DeepEqual(previous.Finalizers, current.Finalizers) {
+			return nil
+		}
+
+		return i.Client.Patch(ctx, current, client.MergeFrom(previous))
+	})
 }

--- a/internal/controllers/translator/controller_test.go
+++ b/internal/controllers/translator/controller_test.go
@@ -1,0 +1,91 @@
+package translator
+
+import (
+	"context"
+	"testing"
+
+	configv1alpha1 "github.com/peak-scale/capsule-argo-addon/api/v1alpha1"
+	"github.com/peak-scale/capsule-argo-addon/internal/meta"
+	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPruneMissingTenantStatuses_RemovesDeletedTenants(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := configv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add config scheme: %v", err)
+	}
+	if err := capsulev1beta2.AddToScheme(scheme); err != nil {
+		t.Fatalf("add capsule scheme: %v", err)
+	}
+
+	translator := &configv1alpha1.ArgoTranslator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "project-translator",
+		},
+		Status: configv1alpha1.ArgoTranslatorStatus{
+			Tenants: []configv1alpha1.TenantStatus{
+				{
+					Name: "tenant-a",
+					UID:  k8stypes.UID("uid-a"),
+					Condition: metav1.Condition{
+						Type:   "Ready",
+						Status: metav1.ConditionTrue,
+					},
+				},
+				{
+					Name: "tenant-b",
+					UID:  k8stypes.UID("uid-b"),
+					Condition: metav1.Condition{
+						Type:   "Ready",
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+			Size:  2,
+			Ready: meta.NotReadyCondition,
+		},
+	}
+	liveTenant := &capsulev1beta2.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tenant-a",
+			UID:  k8stypes.UID("uid-a"),
+		},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(translator, liveTenant).
+		WithStatusSubresource(&configv1alpha1.ArgoTranslator{}).
+		Build()
+	reconciler := &Reconciler{Client: fakeClient}
+
+	pruned, err := reconciler.pruneMissingTenantStatuses(
+		context.Background(),
+		client.ObjectKey{Name: "project-translator"},
+	)
+	if err != nil {
+		t.Fatalf("prune missing tenant statuses: %v", err)
+	}
+	if !pruned {
+		t.Fatal("expected stale tenant status to be pruned")
+	}
+
+	got := &configv1alpha1.ArgoTranslator{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "project-translator"}, got); err != nil {
+		t.Fatalf("get translator: %v", err)
+	}
+
+	if gotNames := got.GetTenantNames(); len(gotNames) != 1 || gotNames[0] != "tenant-a" {
+		t.Fatalf("expected only tenant-a status to remain, got %v", gotNames)
+	}
+	if got.Status.Size != 1 {
+		t.Fatalf("expected status size 1, got %d", got.Status.Size)
+	}
+	if got.Status.Ready != meta.ReadyCondition {
+		t.Fatalf("expected ready status %q, got %q", meta.ReadyCondition, got.Status.Ready)
+	}
+}


### PR DESCRIPTION
ArgoTranslator status can retain tenant entries when a Tenant disappears without a later reconcile for that tenant name. That leaves `.status.tenants`, `.status.size`, readiness, and finalizer decisions derived from tenants that no longer exist.

This PR adds translator-level status cleanup during translator reconciliation.

It prunes stale status entries by:

- listing live Capsule tenants
- removing status entries whose tenant name no longer exists
- removing status entries whose stored UID no longer matches the live tenant UID
- updating translator status only when pruning actually changes it
- syncing metrics and finalizers from the pruned status

## Behavior note

This only removes status entries for tenants that are absent from the cluster or have been replaced with a different UID. Live tenants continue to be reconciled through the tenant controller path.
